### PR TITLE
Faster fromListWord64

### DIFF
--- a/src/HaskellWorks/Data/EliasFano.hs
+++ b/src/HaskellWorks/Data/EliasFano.hs
@@ -17,7 +17,6 @@ import HaskellWorks.Data.AtIndex                 hiding (end)
 import HaskellWorks.Data.Bits.BitWise
 import HaskellWorks.Data.Bits.Log2
 import HaskellWorks.Data.EliasFano.Internal
-import HaskellWorks.Data.Foldable
 import HaskellWorks.Data.FromListWord64
 import HaskellWorks.Data.Positioning
 import HaskellWorks.Data.RankSelect.Base.Select1
@@ -40,9 +39,9 @@ size :: EliasFano -> Count
 size = efCount
 
 instance FromListWord64 EliasFano where
-  fromListWord64 ws = case foldLast ws of
-    Just end' -> EliasFano
-      { efBucketBits  = hiSegmentToBucketWords (bucketEnd - 1) his
+  fromListWord64 ws = case foldCountAndLast ws of
+    (Just end', count) -> EliasFano
+      { efBucketBits  = DVS.fromList $ hiSegmentToWords his
       , efLoSegments  = PV.fromList loBits' los
       , efLoBitCount  = loBits'
       , efCount       = length'
@@ -55,7 +54,7 @@ instance FromListWord64 EliasFano where
             los       = (.&. loMask) <$> ws
             hiEnd     = end' .>. loBits'
             bucketEnd = 1 .<. fromIntegral (finiteBitSize hiEnd - countLeadingZeros hiEnd) :: Word64
-    Nothing -> EliasFano
+    (Nothing, _) -> EliasFano
       { efBucketBits  = DVS.empty
       , efLoSegments  = PV.empty
       , efLoBitCount  = 0

--- a/test/HaskellWorks/Data/EliasFanoSpec.hs
+++ b/test/HaskellWorks/Data/EliasFanoSpec.hs
@@ -4,6 +4,7 @@ module HaskellWorks.Data.EliasFanoSpec (spec) where
 
 import Data.Word
 import HaskellWorks.Data.AtIndex
+import HaskellWorks.Data.Bits.BitShow
 import HaskellWorks.Data.EliasFano
 import HaskellWorks.Data.EliasFano.Internal
 import HaskellWorks.Hspec.Hedgehog
@@ -83,3 +84,11 @@ spec = describe "HaskellWorks.Data.EliasFanoSpec" $ do
     let actual = fmap (atIndex ef) [0 .. end ef - 1]
     let expected = [2, 3, 5, 7, 11, 13, 24]
     actual === expected
+  it "hiSegmentToWords" $ requireTest $ do
+    ws <- forAll $ pure $ [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]
+
+    filter (/= ' ') (bitShow (hiSegmentToWords ws)) === concat
+      [ "01101010", "01000100", "00010000", "00001000", "00000000", "00100000", "00000000", "00000000"
+      , "10000000", "00000000", "00000000", "00000000", "00010000", "00000000", "00000000", "00000000"
+      , "00000000", "00000000", "00000000", "00010000", "00000000", "00000000", "00000000", "00000000"
+      ]


### PR DESCRIPTION
```
benchmarking Load Elias Fano/Load Elias Fano
time                 2.639 s    (2.426 s .. 2.883 s)
                     0.999 R²   (0.996 R² .. 1.000 R²)
mean                 2.623 s    (2.565 s .. 2.655 s)
std dev              54.77 ms   (4.030 ms .. 68.99 ms)
variance introduced by outliers: 19% (moderately inflated)
```